### PR TITLE
fix: consistent units

### DIFF
--- a/include/asw/modules/draw.h
+++ b/include/asw/modules/draw.h
@@ -52,11 +52,11 @@ namespace asw::draw {
   ///
   /// @param tex The texture to draw.
   /// @param position The position to draw the sprite at.
-  /// @param angle The angle to rotate the sprite by in degrees.
+  /// @param angle The angle to rotate the sprite by in radians.
   ///
   void rotateSprite(const asw::Texture& tex,
                     const asw::Vec2<float>& position,
-                    double angle);
+                    float angle);
 
   /// @brief Draw a sprite with the option to stretch a portion of it.
   ///
@@ -76,12 +76,12 @@ namespace asw::draw {
   /// @param source The quad defining the portion of the texture to stretch.
   /// @param dest The quad defining the position and size to stretch the sprite
   /// to.
-  /// @param angle The angle to rotate the sprite by in degrees.
+  /// @param angle The angle to rotate the sprite by in radians.
   ///
   void stretchSpriteRotateBlit(const asw::Texture& tex,
                                const asw::Quad<float>& source,
                                const asw::Quad<float>& dest,
-                               double angle);
+                               float angle);
 
   /// @brief Draw text left aligned.
   ///

--- a/include/asw/modules/game.h
+++ b/include/asw/modules/game.h
@@ -24,10 +24,14 @@ namespace asw::game {
   ///
   class Physics {
    public:
+    // Velocity in pixels per second
     asw::Vec2<float> velocity;
+    // Acceleration in pixels per second squared
     asw::Vec2<float> acceleration;
-    float angularVelocity{0};
-    float angularAcceleration{0};
+    // Angular velocity in radians per second
+    float angularVelocity{0.0F};
+    // Angular acceleration in radians per second squared
+    float angularAcceleration{0.0F};
   };
 
   /// Objects
@@ -43,7 +47,7 @@ namespace asw::game {
 
     /// @brief Update the object.
     ///
-    /// @param deltaTime The time since the last update.
+    /// @param deltaTime The time in seconds since the last update.
     ///
     virtual void update(float deltaTime) {
       body.velocity += body.acceleration * deltaTime;
@@ -66,9 +70,9 @@ namespace asw::game {
     ///
     asw::Quad<float> transform;
 
-    /// @brief The rotation of the object in degrees.
+    /// @brief The rotation of the object in radians.
     ///
-    float rotation{0};
+    float rotation{0.0F};
 
     /// @brief The layer that the object is on.
     /// @details Objects on higher layers are drawn on top of objects on lower
@@ -114,7 +118,7 @@ namespace asw::game {
 
     /// @brief Update the sprite.
     ///
-    /// @param deltaTime The time since the last update.
+    /// @param deltaTime The time in seconds since the last update.
     ///
     void update(float deltaTime) override { GameObject::update(deltaTime); }
 

--- a/include/asw/modules/particles.h
+++ b/include/asw/modules/particles.h
@@ -52,6 +52,10 @@ namespace asw {
   ///
   class ParticleEmitter : public game::GameObject {
    public:
+    /// @brief Create a default ParticleEmitter with no particles.
+    ///
+    ParticleEmitter() = default;
+
     /// @brief Construct a new ParticleEmitter.
     ///
     /// @param config The particle configuration.

--- a/include/asw/modules/particles.h
+++ b/include/asw/modules/particles.h
@@ -21,11 +21,11 @@ namespace asw {
   /// @brief Configuration for particle emitters.
   ///
   struct ParticleConfig {
-    // Lifetime
+    // Lifetime in seconds
     float lifetimeMin{1.0F};
     float lifetimeMax{2.0F};
 
-    // Speed
+    // Speed in pixels per second
     float speedMin{50.0F};
     float speedMax{100.0F};
 
@@ -41,7 +41,7 @@ namespace asw {
     float sizeStart{4.0F};
     float sizeEnd{1.0F};
 
-    // Physics
+    // Physics in pixels per second squared
     Vec2<float> gravity{0.0F, 0.0F};
 
     // Optional texture (nullptr = use circleFill)
@@ -82,7 +82,7 @@ namespace asw {
 
     /// @brief Update particles.
     ///
-    /// @param deltaTime The time since the last update.
+    /// @param deltaTime The time in seconds since the last update.
     ///
     void update(float deltaTime) override;
 
@@ -112,6 +112,8 @@ namespace asw {
     ParticleConfig config;
     std::vector<Particle> particles;
     int aliveCount{0};
+
+    // Emission rate in particles per second
     float emissionRate{0.0F};
     float emissionAccumulator{0.0F};
     bool emitting{false};

--- a/include/asw/modules/scene.h
+++ b/include/asw/modules/scene.h
@@ -245,7 +245,7 @@ namespace asw::scene {
         lag += std::chrono::duration_cast<std::chrono::nanoseconds>(delta_time);
 
         while (lag >= this->timestep) {
-          update(this->timestep / 1s);
+          update(std::chrono::duration<float>(this->timestep).count());
           lag -= this->timestep;
         }
 
@@ -354,7 +354,7 @@ namespace asw::scene {
             std::chrono::high_resolution_clock::now() - SceneManager::em_time;
         SceneManager::em_time = std::chrono::high_resolution_clock::now();
 
-        instance->update(delta_time / 1ms);
+        instance->update(std::chrono::duration<float>(delta_time).count());
         instance->draw();
       }
     }

--- a/include/asw/modules/scene.h
+++ b/include/asw/modules/scene.h
@@ -60,7 +60,7 @@ namespace asw::scene {
 
     /// @brief Update the game scene.
     ///
-    /// @param deltaTime The time since the last update.
+    /// @param deltaTime The time in seconds since the last update.
     /// @details This function is called every frame to update the scene.
     ///
     virtual void update(float deltaTime) {
@@ -245,7 +245,7 @@ namespace asw::scene {
         lag += std::chrono::duration_cast<std::chrono::nanoseconds>(delta_time);
 
         while (lag >= this->timestep) {
-          update(this->timestep / 1ms);
+          update(this->timestep / 1s);
           lag -= this->timestep;
         }
 

--- a/src/modules/draw.cpp
+++ b/src/modules/draw.cpp
@@ -82,7 +82,7 @@ void asw::draw::stretchSprite(const asw::Texture& tex,
 
 void asw::draw::rotateSprite(const asw::Texture& tex,
                              const asw::Vec2<float>& position,
-                             double angle) {
+                             float angle) {
   if (asw::display::renderer == nullptr) {
     return;
   }
@@ -95,8 +95,11 @@ void asw::draw::rotateSprite(const asw::Texture& tex,
   dest.w = size.x;
   dest.h = size.y;
 
+  // Rad to deg
+  const double angleDeg = angle * (180.0 / M_PI);
+
   SDL_RenderTextureRotated(asw::display::renderer, tex.get(), nullptr, &dest,
-                           angle, nullptr, SDL_FLIP_NONE);
+                           angleDeg, nullptr, SDL_FLIP_NONE);
 }
 
 void asw::draw::stretchSpriteBlit(const asw::Texture& tex,
@@ -124,7 +127,7 @@ void asw::draw::stretchSpriteBlit(const asw::Texture& tex,
 void asw::draw::stretchSpriteRotateBlit(const asw::Texture& tex,
                                         const asw::Quad<float>& source,
                                         const asw::Quad<float>& dest,
-                                        double angle) {
+                                        float angle) {
   if (asw::display::renderer == nullptr) {
     return;
   }
@@ -141,8 +144,10 @@ void asw::draw::stretchSpriteRotateBlit(const asw::Texture& tex,
   r_dest.w = dest.size.x;
   r_dest.h = dest.size.y;
 
+  const double angleDeg = angle * (180.0 / M_PI);
+
   SDL_RenderTextureRotated(asw::display::renderer, tex.get(), &r_src, &r_dest,
-                           angle, nullptr, SDL_FLIP_NONE);
+                           angleDeg, nullptr, SDL_FLIP_NONE);
 }
 
 void asw::draw::text(const asw::Font& font,

--- a/src/modules/draw.cpp
+++ b/src/modules/draw.cpp
@@ -262,10 +262,30 @@ void asw::draw::circle(const asw::Vec2<float>& position,
 
   SDL_SetRenderDrawColor(asw::display::renderer, color.r, color.g, color.b,
                          color.a);
-  for (int i = 0; i < 360; i++) {
-    SDL_RenderPoint(asw::display::renderer,
-                    position.x + static_cast<float>(radius * std::cos(i)),
-                    position.y + static_cast<float>(radius * std::sin(i)));
+
+  // Midpoint circle algorithm — no trig, integer arithmetic only
+  int x = static_cast<int>(radius);
+  int y = 0;
+  int err = 1 - x;
+  const float cx = position.x;
+  const float cy = position.y;
+
+  while (x >= y) {
+    SDL_RenderPoint(asw::display::renderer, cx + x, cy + y);
+    SDL_RenderPoint(asw::display::renderer, cx - x, cy + y);
+    SDL_RenderPoint(asw::display::renderer, cx + x, cy - y);
+    SDL_RenderPoint(asw::display::renderer, cx - x, cy - y);
+    SDL_RenderPoint(asw::display::renderer, cx + y, cy + x);
+    SDL_RenderPoint(asw::display::renderer, cx - y, cy + x);
+    SDL_RenderPoint(asw::display::renderer, cx + y, cy - x);
+    SDL_RenderPoint(asw::display::renderer, cx - y, cy - x);
+    y++;
+    if (err < 0) {
+      err += 2 * y + 1;
+    } else {
+      x--;
+      err += 2 * (y - x) + 1;
+    }
   }
 }
 
@@ -278,10 +298,26 @@ void asw::draw::circleFill(const asw::Vec2<float>& position,
 
   SDL_SetRenderDrawColor(asw::display::renderer, color.r, color.g, color.b,
                          color.a);
-  for (int i = 0; i < 360; i++) {
-    SDL_RenderLine(asw::display::renderer, position.x, position.y,
-                   position.x + static_cast<float>(radius * std::cos(i)),
-                   position.y + static_cast<float>(radius * std::sin(i)));
+
+  // Midpoint circle with horizontal scanlines — no gaps, no trig
+  int x = static_cast<int>(radius);
+  int y = 0;
+  int err = 1 - x;
+  const float cx = position.x;
+  const float cy = position.y;
+
+  while (x >= y) {
+    SDL_RenderLine(asw::display::renderer, cx - x, cy + y, cx + x, cy + y);
+    SDL_RenderLine(asw::display::renderer, cx - x, cy - y, cx + x, cy - y);
+    SDL_RenderLine(asw::display::renderer, cx - y, cy + x, cx + y, cy + x);
+    SDL_RenderLine(asw::display::renderer, cx - y, cy - x, cx + y, cy - x);
+    y++;
+    if (err < 0) {
+      err += 2 * y + 1;
+    } else {
+      x--;
+      err += 2 * (y - x) + 1;
+    }
   }
 }
 


### PR DESCRIPTION
# Description
Use consistent units for time (seconds or fractions of seconds vs milliseconds)
Use radians in all functions 
Optimize circle drawing algorithm